### PR TITLE
fix: タイトル属性が未設定のケースを考慮する

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 				return;
 
 			if (!aTarget.hasAttribute('data-popupalt-original-title'))
-				aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title'));
+				aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title') || '');
 			aTarget.setAttribute('title', tooltiptext);
 		},
 


### PR DESCRIPTION

## 再現手順

1. Popup ALT Attributeの拡張設定を開き、"Show more attributes"をチェックする

2. https://www.wikipedia.org にアクセスする。

3. 画面中央のロゴ画像をマウスオーバーする

4. マウスポインタを一旦ロゴ画像から外して、再びマウスオーバーする

## 発生する現象

2度目のマウスオーバー以降、"title:null" という余計な属性値が表示される。

**1度目のマウスオーバー**

![fix_null_title_01](https://user-images.githubusercontent.com/8974561/30437549-d8236b80-99a9-11e7-8daf-63cad9cbaf5e.png)

**2度目のマウスオーバー**

![fix_null_title_02](https://user-images.githubusercontent.com/8974561/30437567-e53a9546-99a9-11e7-98bd-cca90750802e.png)

## 原因

「要素にタイトル属性が設定されていない」場合のハンドリングが原因です：

 * このケースでは `aTarget.getAttribute("title")` は`null`を返します。
 * 元のロジックでは、この`null`値をそのまま退避先にセットしていたので、
   "null"（という文字列）が退避先の属性に設定されていました。

このパッチでは、nullの場合を考慮して、代わりに空文字をセットする小さな処理を入れてます。