### PR TITLE
fix: 初回マウスオーバー時にtitle属性が表示されない

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -108,6 +108,9 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 			if (!aTarget)
 				return;
 
+			if (!aTarget.hasAttribute('data-popupalt-original-title'))
+				aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title') || '');
+
 			var tooltiptext = this.attrlist ?
 					this.constructTooltiptextFromAttributes(aTarget) :
 					this.constructTooltiptextForAlt(aTarget) ;
@@ -115,8 +118,6 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 			if (!tooltiptext || !tooltiptext.match(/\S/))
 				return;
 
-			if (!aTarget.hasAttribute('data-popupalt-original-title'))
-				aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title') || '');
 			aTarget.setAttribute('title', tooltiptext);
 		},
 


### PR DESCRIPTION
### 再現手順

 1. Popup ALTの拡張設定を開き、"Show more attributes"をチェックする
 2. "List of attributes to be shown" に`title`が含まれている事を確認する
 2. https://xkcd.com にアクセスする
 3. 画像をマウスオーバーする

### 発生する現象

画像の`title`属性の値がポップアップに表示されない。
（2回目以降のマウスオーバーでは表示される）

**1回目のマウスオーバー**

![fix_title_attr_1](https://user-images.githubusercontent.com/8974561/30474642-548501f8-9a3f-11e7-8d38-51d055a9b18b.png)


**2回目のマウスオーバー**

![fix_title_attr_2](https://user-images.githubusercontent.com/8974561/30474647-5858d412-9a3f-11e7-82f4-e2d3cf807524.png)


### 原因

関数`updateTooltiptext()`内の処理の順番の問題です：

 1. ツールチップ文字列の生成には`data-popupalt-original-title`属性を利用している。
 2. ...が、この属性はツールチップ文字列を生成した後にしか作成されない。

このため2回目以降でないと`title`属性の中身がうまく表示されませんでした。

このパッチでは単純に関数の処理順序を入れ替えて対応しています。