### PR TITLE
必要な時のみHTML/DOMに独自属性をセットする

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -108,12 +108,14 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 			if (!aTarget)
 				return;
 
-			if (!aTarget.hasAttribute('data-popupalt-original-title'))
-				aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title') || '');
+			if (this.attrlist) {
+				if (!aTarget.hasAttribute('data-popupalt-original-title'))
+					aTarget.setAttribute('data-popupalt-original-title', aTarget.getAttribute('title') || '');
 
-			var tooltiptext = this.attrlist ?
-					this.constructTooltiptextFromAttributes(aTarget) :
-					this.constructTooltiptextForAlt(aTarget) ;
+				var tooltiptext = this.constructTooltiptextFromAttributes(aTarget);
+			} else {
+				var tooltiptext = this.constructTooltiptextForAlt(aTarget);
+			}
 
 			if (!tooltiptext || !tooltiptext.match(/\S/))
 				return;


### PR DESCRIPTION
Popup ALTがHTML/DOMに残すアーティファクトを最小限にする小パッチです。

### 背景にある洞察

現在のPopup Altは、マウスオーバーの際に`data-popupalt-original-title`という
独自の属性を（表示ページの）HTML/DOMに残す仕組みになっています：

![minimize_artifact](https://user-images.githubusercontent.com/8974561/30510145-84851f5e-9af9-11e7-8d10-8401d11f0a67.png)

この独自の属性に関して処理の流れを整理すると、次の事が分かりました：

 * 実は、この属性はデフォルトの（altのみ表示する）モードでは全く使われていない。
 * この属性を参照しているのは「他の属性を表示」が有効になっている時のみ。
   * それ以外の場合は、この属性に`title`の値を複製しなくても動くロジックになっている。

### 修正内容

以上を踏まえて、「他の属性を表示」モードの時のみ`data-popupalt-original-title`属性をセットするように場合分けを入れました。