### PR TITLE
fix: ページ遷移時にクリーンアップ処理が起動しない

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 
 				case 'unload':
 					document.removeEventListener('mousemove', PopupALT, true);
-					document.removeEventListener('unload', PopupALT);
+					window.removeEventListener('unload', PopupALT);
 					PopupALT = undefined;
 					return;
 			}
@@ -206,6 +206,6 @@ document.addEventListener('DOMContentLoaded', function onReady() {
 		.then(function() {
 			log('configs loaded');
 			document.addEventListener('mousemove', PopupALT, true);
-			document.addEventListener('unload', PopupALT);
+			window.addEventListener('unload', PopupALT);
 		});
 });


### PR DESCRIPTION
デバッグ用ログを組み込んで動かしている時に気がついた点のfixです。

PopupAltにはページ遷移時のクリーンアップ用にイベントハンドラが定義されていますが、
実は現状のロジックだと、この処理が意図どおりに動いてないようです。

### 検証手順

 1. `PopupAlt.handleEvent()`関数にログ出力`console.log(aEvent)`を入れる
 2. ブラウザタブを開いて、任意のページを表示する。
 3. 開いたタブ上でリロード (ないし他ページへ遷移）する

### 発生する事象

ページ遷移のタイミングでイベントが発火しないまま、そのまま次のページに遷移します：

![2017-09-20-152215_326x74_scrot](https://user-images.githubusercontent.com/8974561/30630467-b13524ca-9e1b-11e7-95c3-cdcb10020a7c.png)

### 修正内容

`unload`イベントハンドラを紐付ける対象を`document`から`window`に移しました。

改修版で上の検証手順を試して、きちんと処理が発火するようになった事を確認してます：

![2017-09-20-152100_544x147_scrot](https://user-images.githubusercontent.com/8974561/30630473-bedeff92-9e1b-11e7-8478-6ee1b6171821.png)
