### PR TITLE
Fix: title missing on first time hovering over an image

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     imageCovers:     new WeakMap(),
 
     findParentNodeWithOwnTitle(node) {
-      if (!node)
+      if (!node || !node.ownerDocument)
         return null;
 
       return node.ownerDocument.evaluate(
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     },
 
     findParentNodesByAttr(node, attr) {
-      if (!node)
+      if (!node || !node.ownerDocument)
         return [];
 
       const nodes = [];
@@ -137,7 +137,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
 
       let tooltiptext;
       if (this.attrlist) {
-        while (target &&
+        while (target && target.attributes &&
                target.attributes.length == 0) {
           target = target.parentNode;
         }
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     },
 
     constructTooltiptextForAlt(target) {
-      if (target.ownerDocument.contentType.indexOf('image') == 0 ||
+      if ((target.ownerDocument && target.ownerDocument.contentType.indexOf('image') == 0) ||
           !target.alt ||
           (target.title &&
            target.title != target.alt)) {

--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -188,8 +188,9 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
           if (!node) continue;
 
           let realAttrName = attr;
-          if (attr == 'title')
-            realAttrName = 'data-popupalt-original-title';
+          let originalTitleAttrName = 'data-popupalt-original-title'
+          if (attr == 'title' && node.getAttribute(originalTitleAttrName))
+            realAttrName = originalTitleAttrName;
           if (!node.getAttribute(realAttrName))
             continue;
 

--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     imageCovers:     new WeakMap(),
 
     findParentNodeWithOwnTitle(node) {
-      if (!node || !node.ownerDocument)
+      if (!node?.ownerDocument)
         return null;
 
       return node.ownerDocument.evaluate(
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     },
 
     findParentNodesByAttr(node, attr) {
-      if (!node || !node.ownerDocument)
+      if (!node?.ownerDocument)
         return [];
 
       const nodes = [];
@@ -137,7 +137,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
 
       let tooltiptext;
       if (this.attrlist) {
-        while (target && target.attributes &&
+        while (target?.attributes &&
                target.attributes.length == 0) {
           target = target.parentNode;
         }
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', async function onReady() {
     },
 
     constructTooltiptextForAlt(target) {
-      if ((target.ownerDocument && target.ownerDocument.contentType.indexOf('image') == 0) ||
+      if ((target?.ownerDocument?.contentType.indexOf('image') == 0) ||
           !target.alt ||
           (target.title &&
            target.title != target.alt)) {


### PR DESCRIPTION
Hello! I just started using your extension, and noticed that the title attribute wasn't showing in tooltips the first time I hovered over something with a title. I figured out the problem - the extension was looking for the 'data-popupalt-original-title' attribute every time, but that attribute won't exist on the first hover - only on subsequent hovers, after the first hover has saved it. I added a check so if that attribute doesn't exist, it will use the "title" attribute.

I also noticed some null exceptions while I was working on this, and added checks to avoid them in the second commit here. I hope this helps!